### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,6 @@
 name: Nightvision CI
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/jliuhtonen/nightvision/security/code-scanning/1](https://github.com/jliuhtonen/nightvision/security/code-scanning/1)

To fix the problem, we should add an explicit `permissions` key to the workflow. This can be done at the root level (just after the `name:` or `on:` block) to apply least-privilege permissions to all jobs in the workflow unless overridden locally. The minimal recommended permission is `contents: read`, which permits jobs to read the repository contents but not write or administer. This change should be made in .github/workflows/workflow.yml, above or below the `on:` block (usually immediately after `name:` is conventional).

No imports, helper methods, or definitions are required; this is a YAML configuration fix within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
